### PR TITLE
Write model file explicitly via write_model_file option

### DIFF
--- a/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/highs_conif.py
@@ -223,6 +223,11 @@ class HIGHS(ConicSolver):
 
         # initialize and solve problem
         try:
+            # Current HiGHS version do not respect write_model_file and write_model_to_file parameters
+            # expects writeModel function to be called directly by the user
+            if solver_opts.get("write_model_to_file", True) and solver_opts.get("write_model_file"):
+                solver.writeModel(solver_opts["write_model_file"])
+
             solver.run()
             results = {
                 "solution": solver.getSolution(),

--- a/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
+++ b/cvxpy/reductions/solvers/qp_solvers/highs_qpif.py
@@ -203,6 +203,11 @@ class HIGHS(QpSolver):
 
         # initialize and solve problem
         try:
+            # Current HiGHS version do not respect write_model_file and write_model_to_file parameters
+            # expects writeModel function to be called directly by the user
+            if solver_opts.get("write_model_to_file", True) and solver_opts.get("write_model_file"):
+                solver.writeModel(solver_opts["write_model_file"])
+
             solver.run()
             results = {
                 "solution": solver.getSolution(),

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -2180,6 +2180,48 @@ class TestHIGHS:
         }
         problem(solver=cp.HIGHS, highs_options=highs_options)
 
+    @pytest.mark.parametrize(
+        "problem",
+        # it is enough to validate the options with one problem from each type
+        [StandardTestLPs.test_lp_0, StandardTestLPs.test_mi_lp_0],
+    )
+    def test_highs_writes_model(self, problem, tmp_path_factory) -> None:
+        tmp_file_path = tmp_path_factory.mktemp("highs_writes_model") / "model.lp"
+
+        assert not tmp_file_path.exists()
+
+        problem(
+            solver=cp.HIGHS,
+            time_limit=0,
+            write_model_file=str(tmp_file_path),
+        )
+
+        assert tmp_file_path.exists()
+        assert tmp_file_path.is_file()
+        with tmp_file_path.open() as f:
+            assert f.readline() == "\\ File written by HiGHS .lp file handler\n"
+
+    @pytest.mark.parametrize(
+        "problem",
+        # it is enough to validate the options with one problem from each type
+        [StandardTestLPs.test_lp_0, StandardTestLPs.test_mi_lp_0],
+    )
+    def test_highs_options_writes_model(self, problem, tmp_path_factory) -> None:
+        tmp_file_path = tmp_path_factory.mktemp("highs_options_writes_model") / "model.mps"
+
+        assert not tmp_file_path.exists()
+
+        problem(
+            solver=cp.HIGHS,
+            time_limit=0,
+            highs_options=dict(write_model_file=str(tmp_file_path)),
+        )
+
+        assert tmp_file_path.exists()
+        assert tmp_file_path.is_file()
+        with tmp_file_path.open() as f:
+            assert f.readline() == "NAME        \n"
+
 
 class TestAllSolvers(BaseTest):
     def setUp(self) -> None:


### PR DESCRIPTION
## Description
Current HiGHS version expects users to call `writeModel` explicitly. This PR implements this logic inside the highs solver interface.  

Issue link (if applicable):

## Type of change
- [x] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] (N/A) Add our license to new files.
- [x] Check that your code adheres to our coding style.
- [x] Write unittests.
- [x] Run the unittests and check that they’re passing.
- [ ] (CI) Run the benchmarks to make sure your change doesn’t introduce a regression.